### PR TITLE
Adds additional context for troubleshooting the Access Denied page.

### DIFF
--- a/class/Mighty_Gravity_Forms.php
+++ b/class/Mighty_Gravity_Forms.php
@@ -245,7 +245,7 @@ class Mighty_Gravity_Forms
 		if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'gf_download_export') {
 			$this->form_access_already_checked = true;
 
-			return $this->currentUserHasAccessToForm($form['id']) ? $form : die('Access denied!');
+			return $this->currentUserHasAccessToForm($form['id']) ? $form : die('Access denied! Please contact the website administrator to add your user to the roles allowed to export in this specific form\'s settings.');
 		}
 
 		return $form;


### PR DESCRIPTION
The access denied page was completely vague and could have been confused with a litany of possible other issues. Added context to the error message to help with troubleshooting.